### PR TITLE
Allow markdown for `description`s

### DIFF
--- a/lib/betterdocs/generator/markdown/templates/section.md.erb
+++ b/lib/betterdocs/generator/markdown/templates/section.md.erb
@@ -22,7 +22,11 @@
     <th align="left"><%= param.name %></th>
     <td><code><%= param.value %></code></td>
     <td><%= param.required ? 'yes' : 'no' %></td>
-    <td><%= param.description %></td>
+    <td>
+      
+<%= param.description %>
+
+    </td>
   </tr>
 <%- end -%>
 </table>
@@ -57,7 +61,11 @@ are optional.
     <td><code><%= param.value %></code></td>
     <td><%= param.types * ?| -%></td>
     <td><%= param.required ? 'yes' : 'no' %></td>
-    <td><%= param.description %></td>
+    <td>
+  
+<%= param.description %>
+
+    </td>
   </tr>
   <%- end -%>
 </table>
@@ -93,7 +101,11 @@ are optional.
       <%- end -%>
       <td><%= property.types * ' &#124; ' %></td>
       <td><%= property.example %></td>
-      <td><%= property.description %></td>
+      <td>
+
+<%= property.description %>
+
+      </td>
     </tr>
     <%- end -%>
   </table>
@@ -115,7 +127,11 @@ are optional.
   <%- for link in links.group_by(&:nesting_name).values.reduce(&:concat) -%>
     <tr>
       <th align="left"><%= link.full_name %></th>
-      <td><%= link.description %></td>
+      <td>
+
+<%= link.description %>
+
+      </td>
     </tr>
   <%- end -%>
 <%- else -%>


### PR DESCRIPTION
According to https://github.com/github/cmark/issues/12#issuecomment-286683195 it is enough to put newlines around the text to enable markdown rendering even inside a table cell.

@flori kannst Du das mal ausprobieren? Es könnte auch sein, dass man zusätzlich noch die Whitespaces for den TDs entfernen muss. Aber ein Test dürfte das schnell zeigen.