### PR TITLE
Generate example with correct attributes and as json

### DIFF
--- a/lib/betterdocs/generator/markdown/templates/section.md.erb
+++ b/lib/betterdocs/generator/markdown/templates/section.md.erb
@@ -154,7 +154,7 @@ are optional.
 ## Response Example
 
 ```json
-<%= JSON.pretty_generate(action.response, quirks_mode: true) %>
+<%= JSON.pretty_generate(action.response.data.as_json, quirks_mode: true) %>
 ```
 
 <%- end -%>


### PR DESCRIPTION
When creating the API documentation the generated examples did not come out right. So @riccardo-giomi and I came up with this quick patch. 

We had to force the response to json as in #8. Additionally we had to pick only the data from the response that included other attributes which we don't want in the documentation.